### PR TITLE
feat: possible to override API url for the UI to use

### DIFF
--- a/src/ui/client.ts
+++ b/src/ui/client.ts
@@ -1,6 +1,12 @@
 import { Tx, TxStatus } from '../types';
 
-const API_URL = "http://localhost:3000/api/v1/tx" || process.env.API_URL;
+let API_URL: string;
+
+if (process.env.API_URL) {
+  API_URL = process.env.API_URL;
+} else {
+  API_URL = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/api/v1/tx`;
+}
 
 export async function getAllTransmitters(): Promise<Tx[]> {
   const response = await fetch(API_URL);

--- a/src/ui/client.ts
+++ b/src/ui/client.ts
@@ -2,8 +2,11 @@ import { Tx, TxStatus } from '../types';
 
 let API_URL: string;
 
-if (process.env.API_URL) {
-  API_URL = process.env.API_URL;
+const params = new URLSearchParams(window.location.search);
+const apiUrl = params.get('apiUrl');
+
+if (apiUrl) {
+  API_URL = apiUrl;
 } else {
   API_URL = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/api/v1/tx`;
 }

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta
       name="description"
-      content="Demonstration of the WHIP Client SDK for Web by Eyevinn Technology AB"
+      content="SRT WHIP Gateway by Eyevinn Technology AB"
     />
     <script type="module" src="./app.ts"></script>
     <style type="text/css">


### PR DESCRIPTION
This PR addresses #1 and with the query param `apiUrl` a client can override what API url to use. Defaults to the same host and port as the UI is loaded from.