### PR TITLE
fix: add param input fields to swagger

### DIFF
--- a/src/api/engine.ts
+++ b/src/api/engine.ts
@@ -9,6 +9,13 @@ export interface ApiEngineOpts {
   apiKey?: string;
 }
 
+
+const ParamsPort = Type.Object({
+  port: Type.Integer({
+    description: 'SRT port'
+  })
+})
+
 const apiEngine: FastifyPluginCallback<ApiEngineOpts> = (fastify, opts, next) => {
   let apiKey = '';
   if (opts.apiKey) {
@@ -54,6 +61,7 @@ const apiEngine: FastifyPluginCallback<ApiEngineOpts> = (fastify, opts, next) =>
     {
       schema: {
         description: 'Obtain a transmitter resource for an SRT port',
+        params: ParamsPort,
         response: {
           200: Tx,
           500: Type.String({ description: 'Error message' })
@@ -81,6 +89,7 @@ const apiEngine: FastifyPluginCallback<ApiEngineOpts> = (fastify, opts, next) =>
     {
       schema: {
         description: 'Remove a transmitter for an SRT port',
+        params: ParamsPort,
         response: {
           500: Type.String({ description: 'Error message' }),
         }
@@ -129,6 +138,7 @@ const apiEngine: FastifyPluginCallback<ApiEngineOpts> = (fastify, opts, next) =>
     {
       schema: {
         description: 'Change state of a transmitter',
+        params: ParamsPort,
         body: TxStateChange,
         response: {
           200: Type.String(),


### PR DESCRIPTION
Previously it was not possible to try endpoints in the API Swagger, this PR adds a port input for the endpoints that requires it as a parameter:

Before:
<img width="722" height="248" alt="Skärmavbild 2025-10-07 kl  20 19 28" src="https://github.com/user-attachments/assets/fe0a8af0-7c72-416f-beb5-fcce6a7d3318" />

After:
<img width="1444" height="754" alt="image" src="https://github.com/user-attachments/assets/6e6391db-1099-41b5-a807-d39b0c2ca44e" />
