### PR TITLE
feat: persist transmitter configuration across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 dist/
 .parcel-cache/
+data/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ docker run -d -p 3000:3000 -p 9000-9999:9000-9999/udp \
 
 Once the container is up and running you can access the API at `http://localhost:3000/api/docs` and the Web GUI at `http://localhost:3000/ui`.
 
+### Configuration
+
+The service is configured through environment variables.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | HTTP port for the API and Web GUI |
+| `API_KEY` | _(unset)_ | If set, required in the `x-api-key` header for API requests |
+| `DATA_DIR` | `./data` | Directory where transmitter configuration is persisted |
+
+Configured transmitters (SRT port, WHIP URL and optional pass-through URL) are
+persisted to a JSON file (`transmitters.json`) under `DATA_DIR` so they survive a
+process restart. Runtime status is not persisted - a reloaded transmitter starts
+in the `idle` state and can be started again. Mount `DATA_DIR` to a durable volume
+when running in a container to retain configuration across restarts.
+
 ## Run SRT WHIP Gateway with WHIP/WHEP local
 
 To run the SRT WHIP Gateway with [WHIP/WHEP local development environment](https://github.com/Eyevinn/whip-whep) you need to attach the SRT WHIP Gateway container to the same network as the WHIP/WHEP containers are running on.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,11 +1,57 @@
 import { Transmitter } from './transmitter';
 import { TxStatus } from './types';
+import {
+  InMemoryTransmitterStore,
+  TransmitterConfig,
+  TransmitterStore
+} from './store';
+
+export interface EngineOptions {
+  store?: TransmitterStore;
+}
 
 export class Engine {
   private transmitters: Map<number, Transmitter>;
+  private store: TransmitterStore;
 
-  constructor() {
+  constructor(opts: EngineOptions = {}) {
     this.transmitters = new Map<number, Transmitter>();
+    this.store = opts.store ? opts.store : new InMemoryTransmitterStore();
+  }
+
+  /**
+   * Reload previously configured transmitters from the backing store. Should be
+   * called on startup, before the API starts serving requests. Only the
+   * configuration is restored - runtime status re-derives when a transmitter is
+   * (re-)started.
+   */
+  async load(): Promise<void> {
+    const configs = await this.store.load();
+    for (const config of configs) {
+      if (this.transmitters.has(config.port)) {
+        continue;
+      }
+      const transmitter = new Transmitter(
+        config.port,
+        new URL(config.whipUrl),
+        config.passThroughUrl ? new URL(config.passThroughUrl) : undefined
+      );
+      this.transmitters.set(config.port, transmitter);
+    }
+  }
+
+  private async persist(): Promise<void> {
+    const configs: TransmitterConfig[] = [];
+    this.transmitters.forEach((tx) => {
+      const whipUrl = tx.getWhipUrl();
+      const passThroughUrl = tx.getPassThroughUrl();
+      configs.push({
+        port: tx.getPort(),
+        whipUrl: whipUrl.toString(),
+        passThroughUrl: passThroughUrl ? passThroughUrl.toString() : undefined
+      });
+    });
+    await this.store.save(configs);
   }
 
   async addTransmitter(srtPort: number, whipUrl: URL, passThroughUrl?: URL, mockSpawn?): Promise<Transmitter> {
@@ -14,6 +60,7 @@ export class Engine {
     }
     const transmitter = new Transmitter(srtPort, whipUrl, passThroughUrl, mockSpawn);
     this.transmitters.set(srtPort, transmitter);
+    await this.persist();
     return transmitter;
   }
 
@@ -22,6 +69,7 @@ export class Engine {
     if (tx) {
       if ([ TxStatus.STOPPED, TxStatus.FAILED, TxStatus.IDLE ].includes(tx.getStatus())) {
         this.transmitters.delete(srtPort);
+        await this.persist();
       } else {
         throw new Error(`Failed to remove transmitter for port ${srtPort} as it is active`);
       }
@@ -38,7 +86,7 @@ export class Engine {
     this.transmitters.forEach((tx) => transmitters.push(tx));
     return transmitters;
   }
-  
+
   removeAllTransmitters(): void {
     this.transmitters.clear();
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,8 +2,11 @@ import gui from '@fastify/static';
 import path from 'path';
 import api from "./api";
 import { Engine } from "./engine";
+import { FileTransmitterStore } from "./store";
 
-const engine = new Engine();
+const DATA_DIR = process.env.DATA_DIR ? process.env.DATA_DIR : path.join(process.cwd(), 'data');
+
+const engine = new Engine({ store: new FileTransmitterStore(DATA_DIR) });
 
 const server = api({
   engine: engine,
@@ -19,10 +22,17 @@ server.get('/ui/', (req, reply) => {
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3000;
 
-server.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {
-  if (err) {
-    console.error(err);
-    process.exit(1);
-  }
-  console.log(address);
-});
+const start = async () => {
+  // Reload previously configured transmitters before serving requests.
+  await engine.load();
+
+  server.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    console.log(address);
+  });
+};
+
+start();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { Engine } from './engine';
+import { FileTransmitterStore } from './store';
+import { logger } from './util/logger';
+
+describe('Transmitter config persistence', () => {
+  let dataDir: string;
+
+  beforeAll(() => {
+    logger.level = 'error';
+  });
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'srt-whip-gw-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  test('added transmitters survive a restart (reload returns the same set)', async () => {
+    const store = new FileTransmitterStore(dataDir);
+    const engine = new Engine({ store });
+    await engine.addTransmitter(1234, new URL('https://whip/channel/a'));
+    await engine.addTransmitter(2345, new URL('https://whip/channel/b'), new URL('srt://dummy:9000'));
+
+    // Simulate a process restart: a brand new Engine on the same store.
+    const restarted = new Engine({ store: new FileTransmitterStore(dataDir) });
+    await restarted.load();
+
+    const ports = restarted
+      .getAllTransmitters()
+      .map((tx) => tx.getPort())
+      .sort((a, b) => a - b);
+    expect(ports).toEqual([1234, 2345]);
+
+    const tx = restarted.getTransmitter(2345);
+    expect(tx.getWhipUrl().toString()).toEqual('https://whip/channel/b');
+    expect(tx.getPassThroughUrl().toString()).toEqual('srt://dummy:9000');
+  });
+
+  test('a removed transmitter is not resurrected after a restart', async () => {
+    const store = new FileTransmitterStore(dataDir);
+    const engine = new Engine({ store });
+    await engine.addTransmitter(1234, new URL('https://whip/channel/a'));
+    await engine.addTransmitter(2345, new URL('https://whip/channel/b'));
+    await engine.removeTransmitter(1234);
+
+    const restarted = new Engine({ store: new FileTransmitterStore(dataDir) });
+    await restarted.load();
+
+    const ports = restarted.getAllTransmitters().map((tx) => tx.getPort());
+    expect(ports).toEqual([2345]);
+    expect(restarted.getTransmitter(1234)).toBeUndefined();
+  });
+
+  test('runtime status is not persisted (reloaded transmitters are idle)', async () => {
+    const store = new FileTransmitterStore(dataDir);
+    const engine = new Engine({ store });
+    await engine.addTransmitter(1234, new URL('https://whip/channel/a'));
+
+    const restarted = new Engine({ store: new FileTransmitterStore(dataDir) });
+    await restarted.load();
+
+    const tx = restarted.getTransmitter(1234);
+    // status re-derives to IDLE on reload; it is not read from the store
+    expect(tx.getObject().status).toEqual('idle');
+  });
+
+  test('load on a fresh data directory yields no transmitters', async () => {
+    const engine = new Engine({ store: new FileTransmitterStore(dataDir) });
+    await engine.load();
+    expect(engine.getAllTransmitters().length).toEqual(0);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from './util/logger';
+
+/**
+ * The persisted configuration for a single transmitter. This is intentionally
+ * only the *configuration* required to re-create a transmitter on startup - the
+ * runtime status (TxStatus) is deliberately not persisted as it re-derives when
+ * the transmitter is re-spawned.
+ */
+export interface TransmitterConfig {
+  port: number;
+  whipUrl: string;
+  passThroughUrl?: string;
+}
+
+/**
+ * Store abstraction for transmitter configuration. The Engine writes through to
+ * a store on add/remove and reloads from it on startup.
+ */
+export interface TransmitterStore {
+  load(): Promise<TransmitterConfig[]>;
+  save(configs: TransmitterConfig[]): Promise<void>;
+}
+
+/**
+ * A no-op store used when persistence is not desired (e.g. in unit tests that
+ * construct an Engine without a backing store). Nothing is written to disk and
+ * load always returns an empty set.
+ */
+export class InMemoryTransmitterStore implements TransmitterStore {
+  private configs: TransmitterConfig[] = [];
+
+  async load(): Promise<TransmitterConfig[]> {
+    return this.configs.slice();
+  }
+
+  async save(configs: TransmitterConfig[]): Promise<void> {
+    this.configs = configs.slice();
+  }
+}
+
+/**
+ * Persists transmitter configuration to a JSON file under a configurable data
+ * directory. This is intentionally simple - a single JSON document holding the
+ * full set of configured transmitters, rewritten on every change.
+ */
+export class FileTransmitterStore implements TransmitterStore {
+  private filePath: string;
+
+  constructor(dataDir: string, fileName = 'transmitters.json') {
+    this.filePath = path.join(dataDir, fileName);
+  }
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  async load(): Promise<TransmitterConfig[]> {
+    try {
+      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        logger.warn(
+          `Ignoring transmitter store at ${this.filePath}: expected an array`
+        );
+        return [];
+      }
+      return parsed as TransmitterConfig[];
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // No store yet - first run.
+        return [];
+      }
+      logger.warn(
+        `Failed to read transmitter store at ${this.filePath}: ${err}`
+      );
+      return [];
+    }
+  }
+
+  async save(configs: TransmitterConfig[]): Promise<void> {
+    await fs.promises.mkdir(path.dirname(this.filePath), { recursive: true });
+    const tmpPath = `${this.filePath}.tmp`;
+    await fs.promises.writeFile(tmpPath, JSON.stringify(configs, null, 2), 'utf-8');
+    await fs.promises.rename(tmpPath, this.filePath);
+  }
+}


### PR DESCRIPTION
## Summary
- Implements #39: persist transmitter configuration across restarts

## Changes
- Add `src/store.ts` with a `TransmitterStore` interface, a `FileTransmitterStore` (atomic JSON-file writes under a configurable data dir, tolerant of a missing/corrupt file on load), and an `InMemoryTransmitterStore` no-op used as the default.
- `src/engine.ts`: `Engine` now takes an optional `{ store }`. `addTransmitter`/`removeTransmitter` write through to the store; a new `load()` reloads previously configured transmitters. Only configuration is persisted, never runtime `TxStatus` (it re-derives to `idle` on reload). Defaults to the in-memory no-op store so existing unit tests do no disk I/O.
- `src/server.ts`: construct a `FileTransmitterStore` (dir from `DATA_DIR`, default `./data`) and `await engine.load()` before `server.listen`, so reload happens before the API serves requests.
- `.gitignore`: ignore `data/`.
- `README.md`: document the `DATA_DIR`/`PORT`/`API_KEY` env vars and the persistence behavior.
- `src/store.test.ts`: new tests covering add + restart-reload returns the same set, remove + restart-reload does not resurrect, runtime status is not persisted, and fresh dir loads empty. Uses `fs.mkdtempSync` temp dirs with cleanup, so no stray files on disk.

## Test plan
- `npm run lint` -> clean, no errors:
  ```
  > eslint . --ext .ts
  ```
- `npm test` -> all suites pass (existing `engine.test.ts` / `transmitter.test.ts` / `api.test.ts` plus new `store.test.ts`):
  ```
  PASS src/store.test.ts
  PASS src/engine.test.ts
  PASS src/api.test.ts
  PASS src/transmitter.test.ts
  Test Suites: 4 passed, 4 total
  Tests:       24 passed, 24 total
  ```
- `npm run build` -> compiles clean (exit 0).

Closes #39

🤖 Automated via WebRTC daily-backlog-pr skill