### PR TITLE
fix: healthcheck reflects transmitter engine state

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -15,6 +15,75 @@ describe('API', () => {
     expect(response.statusCode).toEqual(200);
     const body = await response.json();
     expect(body.message).toEqual('ok');
+    // Backward compatibility: docs and gui links must be preserved
+    expect(body.docs).toEqual('/api/docs');
+    expect(body.gui).toEqual('/ui');
+  });
+
+  test('healthcheck returns 200 when all transmitters are running/idle', async () => {
+    const engine = new Engine();
+    const app = api({ engine });
+    const mockSpawn = MockSpawn();
+    let t;
+    mockSpawn.setDefault((cb) => {
+      // Stay running for a while so status remains RUNNING during the check
+      t = setTimeout(() => {
+        return cb(0);
+      }, 2000);
+    });
+    // One idle transmitter and one running transmitter
+    await engine.addTransmitter(7001, new URL('http://whip/idle'));
+    const tx = await engine.addTransmitter(
+      7002,
+      new URL('http://whip/running'),
+      undefined,
+      mockSpawn
+    );
+    await tx.start();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    });
+    expect(response.statusCode).toEqual(200);
+    const body = await response.json();
+    expect(body.message).toEqual('ok');
+    expect(body.docs).toEqual('/api/docs');
+    expect(body.gui).toEqual('/ui');
+    expect(body.transmitters.total).toEqual(2);
+    expect(body.transmitters.failed).toEqual(0);
+    clearTimeout(t);
+  });
+
+  test('healthcheck returns non-2xx when a transmitter has failed', async () => {
+    const engine = new Engine();
+    const app = api({ engine });
+    const mockSpawn = MockSpawn();
+    mockSpawn.setDefault((cb) => {
+      // Exit with a non-zero code immediately to mark the transmitter FAILED
+      return cb(1);
+    });
+    const tx = await engine.addTransmitter(
+      7003,
+      new URL('http://whip/failing'),
+      undefined,
+      mockSpawn
+    );
+    await tx.start();
+    // Wait for the process 'exit' handler to flip the status to FAILED
+    await tx.waitFor({ desiredStatus: [TxStatus.FAILED] });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    });
+    expect(response.statusCode).toBeGreaterThanOrEqual(300);
+    const body = await response.json();
+    expect(body.message).toEqual('unhealthy');
+    // Backward compatibility preserved even in the unhealthy response
+    expect(body.docs).toEqual('/api/docs');
+    expect(body.gui).toEqual('/ui');
+    expect(body.transmitters.failed).toBeGreaterThanOrEqual(1);
   });
 
   test('can return a list of all transmitters', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -42,7 +42,8 @@ export default (opts: ApiOptions) => {
     apiKey: opts.apiKey
   });
   api.register(ApiHealthcheck, {
-    prefix: '/'
+    prefix: '/',
+    engine: opts.engine
   });
 
   return api;

--- a/src/api/healthcheck.ts
+++ b/src/api/healthcheck.ts
@@ -1,11 +1,55 @@
-export default (fastify, opts, next) => {
+import { FastifyPluginCallback } from 'fastify';
+
+import { Engine } from '../engine';
+import { TxStatus } from '../types';
+
+export interface ApiHealthcheckOpts {
+  engine: Engine;
+}
+
+const apiHealthcheck: FastifyPluginCallback<ApiHealthcheckOpts> = (
+  fastify,
+  opts,
+  next
+) => {
   fastify.get('/', async (request, reply) => {
-    reply.send({
-      message: 'ok',
+    const transmitters = opts.engine.getAllTransmitters();
+
+    const counts = {
+      idle: 0,
+      running: 0,
+      stopped: 0,
+      failed: 0
+    };
+    transmitters.forEach((tx) => {
+      const status = tx.getStatus();
+      if (status === TxStatus.IDLE) {
+        counts.idle++;
+      } else if (status === TxStatus.RUNNING) {
+        counts.running++;
+      } else if (status === TxStatus.STOPPED) {
+        counts.stopped++;
+      } else if (status === TxStatus.FAILED) {
+        counts.failed++;
+      }
+    });
+
+    // Unhealthy when at least one transmitter has failed. Zero transmitters or
+    // transmitters that are only idle/running/stopped are considered healthy.
+    const healthy = counts.failed === 0;
+
+    reply.code(healthy ? 200 : 503).send({
+      message: healthy ? 'ok' : 'unhealthy',
       component: 'srt-whip-gateway',
       docs: '/api/docs',
-      gui: '/ui'
+      gui: '/ui',
+      transmitters: {
+        total: transmitters.length,
+        ...counts
+      }
     });
   });
   next();
-}
+};
+
+export default apiHealthcheck;


### PR DESCRIPTION
## Summary
- Implements #40: the healthcheck endpoint now reflects transmitter engine state instead of returning an unconditional 200.

## Changes
- **Modified `GET /` in place** (did NOT add a separate `GET /health`). Rationale: the GUI is served as static assets under `/ui/` (`src/server.ts` registers `@fastify/static` + `server.get('/ui/')`) and the browser client (`src/ui/client.ts`) only ever calls `/api/v1/tx`. Swagger docs live at `/api/docs`. Nothing consumes `/` except as an informational health probe, so changing its status code is safe. Adding a second `/health` route would have left `/` returning a false 200 for orchestrators that probe it — worse than fixing the existing route. The `message`/`component`/`docs`/`gui` body fields are preserved for backward compatibility.
- `src/api/healthcheck.ts`: converted to a typed `FastifyPluginCallback<ApiHealthcheckOpts>` that receives the `Engine`, aggregates transmitter statuses via `engine.getAllTransmitters()` / `tx.getStatus()`, and returns:
  - `200 { message: 'ok', ... }` when there are zero transmitters or none are `FAILED` (idle/running/stopped all considered healthy).
  - `503 { message: 'unhealthy', ... }` when at least one transmitter is `TxStatus.FAILED`.
  - Added a non-breaking `transmitters` summary object (`total`, `idle`, `running`, `stopped`, `failed`) to the body.
- `src/api.ts`: wired `engine: opts.engine` through to the `ApiHealthcheck` plugin (it previously only received `prefix: '/'`).
- `src/api.test.ts`: extended the existing `/` test to assert the `docs`/`gui` links are preserved, and added two new tests covering BOTH branches (healthy 200 with idle+running transmitters; failed transmitter -> non-2xx).

## Test plan
PROOF (`npm run lint`):
```
> @eyevinn/srt-whip-gateway@0.4.0 lint
> eslint . --ext .ts
(no errors)
```
PROOF (`npm test`):
```
Test Suites: 3 passed, 3 total
Tests:       22 passed, 22 total
```
PROOF (new both-branch tests, `npx jest src/api.test.ts --verbose`):
```
✓ returns healtheck response on /
✓ healthcheck returns 200 when all transmitters are running/idle
✓ healthcheck returns non-2xx when a transmitter has failed
Tests:       12 passed, 12 total
```
PROOF (`npm run build`): `tsc --project ./` exits 0.

Closes #40

🤖 Automated via WebRTC daily-backlog-pr skill