### PR TITLE
chore: add explicit dependabot.yml (closes #41)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
Adds an explicit `.github/dependabot.yml` to srt-whip-gateway, which previously ran entirely on an undocumented org-level Dependabot default. Broken out from Eyevinn/srt-whep#130.

The config mirrors the grouping policy of the sibling repo `Eyevinn/srt-whep` (a single group batching `minor` + `patch` updates via `patterns: ["*"]`), adapting the ecosystem from `cargo` to `npm` (this is the TypeScript/Node service) and adding a `github-actions` ecosystem entry for the workflows in `.github/workflows`.

## Changes
- Add `.github/dependabot.yml` with two update entries:
  - `npm` (directory `/`, weekly, grouped minor+patch, PR limit 10)
  - `github-actions` (directory `/`, weekly, grouped minor+patch, PR limit 10)

## Test plan
Config-only change (no source code touched); tests are unaffected but were run to confirm no regression.

PROOF:
- `node -e "js-yaml load .github/dependabot.yml"` -> `parsed ecosystems: npm,github-actions` / `YAML_OK`
- `npm ci` -> succeeded (dependencies installed)
- `npm run lint` (eslint . --ext .ts) -> LINT_EXIT=0 (no errors)
- `npm test` (jest) -> `Test Suites: 4 passed, 4 total` / `Tests: 26 passed, 26 total` / TEST_EXIT=0

Closes #41

🤖 Automated via WebRTC daily-backlog-pr skill